### PR TITLE
Fix crash that occurs with empty headers with trailing whitespace when using TOC or header ids

### DIFF
--- a/src/context_test.c
+++ b/src/context_test.c
@@ -85,10 +85,20 @@ static void
 rndr_listitem(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, hoedown_list_flags *flags, const hoedown_renderer_data *data)
 {
 	uint8_t c;
+	const hoedown_buffer* ol_numeral;
 
-	c = hoedown_document_ul_item_char(((hoedown_context_test_renderer_state*) data->opaque)->doc);
-	hoedown_buffer_putc(ob, c);
-	hoedown_buffer_putc(ob, ' ');
+	ol_numeral = hoedown_document_ol_numeral(((hoedown_context_test_renderer_state*) data->opaque)->doc);
+	if (ol_numeral) {
+		hoedown_buffer_put(ob, ol_numeral->data, ol_numeral->size);
+		hoedown_buffer_puts(ob, ". ");
+	} else {
+		c = hoedown_document_ul_item_char(((hoedown_context_test_renderer_state*) data->opaque)->doc);
+		if (c) {
+			hoedown_buffer_putc(ob, c);
+			hoedown_buffer_putc(ob, ' ');
+		}
+	}
+
 	if (content) hoedown_buffer_put(ob, content->data, content->size);
 }
 

--- a/src/document.h
+++ b/src/document.h
@@ -234,6 +234,9 @@ uint8_t hoedown_document_hrule_char(hoedown_document* document);
 /* returns the character used for the currently processing fenced code block (` or ~), or 0 if not processing a fenced code block */
 uint8_t hoedown_document_fencedcode_char(hoedown_document* document);
 
+/* returns the text of the numeral that begins an ordered list item, or NULL if not processing an ordered list item */
+const hoedown_buffer* hoedown_document_ol_numeral(hoedown_document* document);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/Tests/context/Ordered_Lists.input
+++ b/test/Tests/context/Ordered_Lists.input
@@ -1,0 +1,6 @@
+1. foo
+23. bar
+0. baz
+82938. bat
+  7. foo
+  16. bar

--- a/test/Tests/context/Ordered_Lists.output
+++ b/test/Tests/context/Ordered_Lists.output
@@ -1,0 +1,6 @@
+1. foo
+23. bar
+0. baz
+82938. bat
+  7. foo
+  16. bar

--- a/test/config.json
+++ b/test/config.json
@@ -255,6 +255,11 @@
             "flags": ["--context-test"]
         },
         {
+            "input": "Tests/context/Ordered_Lists.input",
+            "output": "Tests/context/Ordered_Lists.output",
+            "flags": ["--context-test"]
+        },
+        {
             "input": "Tests/context/Depth.input",
             "output": "Tests/context/Depth.output",
             "flags": ["--context-test"]


### PR DESCRIPTION
Fix crash that occurs with empty headers with trailing whitespace when using TOC or header ids. Defence in depth: handle NULLs properly in toc_header and rndr_header, but also change is_atxheader logic so that a header consisting only of whitespace isn't considered a header. This should prevent the header callback from ever being called with NULL content.
