### PR TITLE
Strip whitespace, not just spaces, from the beginning and ends of codespans

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -982,13 +982,13 @@ char_codespan(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t o
 	if (i < nb && end >= size)
 		return 0; /* no matching delimiter */
 
-	/* trimming outside spaces */
+	/* trimming outside whitespace */
 	f_begin = nb;
-	while (f_begin < end && data[f_begin] == ' ')
+	while (f_begin < end && (data[f_begin] == ' ' || data[f_begin] == '\n'))
 		f_begin++;
 
 	f_end = end - nb;
-	while (f_end > nb && data[f_end-1] == ' ')
+	while (f_end > nb && (data[f_end-1] == ' ' || data[f_end-1] == '\n'))
 		f_end--;
 
 	/* real code span */

--- a/test/Tests/extras/Codespans.html
+++ b/test/Tests/extras/Codespans.html
@@ -1,0 +1,9 @@
+<p><code>foo</code></p>
+
+<p><code>bar</code></p>
+
+<p><code>baz</code></p>
+
+<p><code>bat</code></p>
+
+<p><code>foo bar</code></p>

--- a/test/Tests/extras/Codespans.text
+++ b/test/Tests/extras/Codespans.text
@@ -1,0 +1,16 @@
+` foo `
+
+`bar
+`
+
+`
+baz`
+
+`
+bat
+`
+
+`
+foo
+bar
+`

--- a/test/config.json
+++ b/test/config.json
@@ -220,6 +220,11 @@
             "flags": ["--html-toc", "-t", "1", "--header-id", "--special-attribute"]
         },
         {
+            "input": "Tests/extras/Codespans.text",
+            "output": "Tests/extras/Codespans.html",
+            "flags": []
+        },
+        {
             "input": "Tests/context/Escaping.input",
             "output": "Tests/context/Escaping.output",
             "flags": ["--context-test"]


### PR DESCRIPTION
Without this, you get an ugly extra space at the end of codespans that end with a new line, in the rendered form in the browser (at least in Chrome).

Consider this example:

<img width="66" alt="screen shot 2015-09-22 at 10 42 29 pm" src="https://cloud.githubusercontent.com/assets/283954/10036844/6449517e-617b-11e5-8507-d708bbb23ea4.png">

This is from

```
`foo
` bar
```

The top line is AFTER the change. The codespan hugs its contents, and looks good.

The bottom line is BEFORE the change. The codespan covers the space just after the codespan's contents, and looks ugly.
