### PR TITLE
Fix escaped backticks in codespans again

### DIFF
--- a/test/Tests/extras/Codespans.html
+++ b/test/Tests/extras/Codespans.html
@@ -7,3 +7,5 @@
 <p><code>bat</code></p>
 
 <p><code>foo bar</code></p>
+
+<p><code>a \` b \` c</code></p>

--- a/test/Tests/extras/Codespans.text
+++ b/test/Tests/extras/Codespans.text
@@ -14,3 +14,5 @@ bat
 foo
 bar
 `
+
+` a \` b \` c `

--- a/test/Tests/extras/Escape_Backticks.html
+++ b/test/Tests/extras/Escape_Backticks.html
@@ -1,4 +1,4 @@
 <p>`<code>
 bar
-`</code><code>
-`</code>`<p>
+\`</code><code>
+\`</code>`<p>


### PR DESCRIPTION
The existing behavior is wrong according to the original Markdown test suite. It is clear in the "test/MarkdownTest_1.0.3/Tests/Backslash escapes.text" test case that backslashes should be preserved in the HTML output, if they're inside codespans, but the existing behavior of the code is to strip backslashes before backticks out.

As a bonus this significantly simplifies codespan parsing code.
