### PR TITLE
Cherrypicks d8d37c3013 from hoedown/hoedown

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -456,9 +456,23 @@ tag_length(uint8_t *data, size_t size, hoedown_autolink_type *autolink, int scri
 	/* a valid tag can't be shorter than 3 chars */
 	if (size < 3) return 0;
 
-	/* begins with a '<' optionally followed by '/', followed by letter or number */
 	if (data[0] != '<') return 0;
-	i = (data[1] == '/') ? 2 : 1;
+
+        /* HTML comment, laxist form */
+        if (size > 5 && data[1] == '!' && data[2] == '-' && data[3] == '-') {
+		i = 5;
+
+		while (i < size && !(data[i - 2] == '-' && data[i - 1] == '-' && data[i] == '>'))
+			i++;
+
+		i++;
+
+		if (i <= size)
+			return i;
+        }
+
+	/* begins with a '<' optionally followed by '/', followed by letter or number */
+        i = (data[1] == '/') ? 2 : 1;
 
 	if (!isalnum(data[i])) {
 		if (script_tag) {

--- a/src/html_smartypants.c
+++ b/src/html_smartypants.c
@@ -314,7 +314,7 @@ smartypants_cb__ltag(hoedown_buffer *ob, struct smartypants_data *smrt, uint8_t 
 	size_t tag, i = 0;
 
 	/* This is a comment. Copy everything verbatim until --> or EOF is seen. */
-	if (i + 4 < size && memcmp(text, "<!--", 4) == 0) {
+	if (i + 4 < size && memcmp(text + i, "<!--", 4) == 0) {
 		i += 4;
 		while (i + 3 < size && memcmp(text + i, "-->",  3) != 0)
 			i++;

--- a/test/Tests/CommentsInMiddleOfLine.html
+++ b/test/Tests/CommentsInMiddleOfLine.html
@@ -1,0 +1,6 @@
+<p>It would be super-keen to be able to use <a href=
+"https://github.com/google/moe">MOE</a> directives in Markdown.</p>
+<!-- HTML comments work at the start of a block -->
+<p>But I'd <!-- MOE:begin_strip -->really, really
+<!-- MOE:end_strip -->
+like to be able to use them in the middle of a line.</p>

--- a/test/Tests/CommentsInMiddleOfLine.text
+++ b/test/Tests/CommentsInMiddleOfLine.text
@@ -1,0 +1,8 @@
+It would be super-keen to be able to use [MOE](https://github.com/google/moe)
+directives in Markdown.
+
+<!-- HTML comments work at the start of a block -->
+
+But I'd <!-- MOE:begin_strip -->really, really <!-- MOE:end_strip -->
+like to be able to use them in the middle of a line.
+

--- a/test/config.json
+++ b/test/config.json
@@ -98,6 +98,10 @@
             "flags": ["--html-toc", "-t", "3"]
         },
         {
+            "input": "Tests/CommentsInMiddleOfLine.text",
+            "output": "Tests/CommentsInMiddleOfLine.html"
+        },
+        {
             "input": "Tests/Math.text",
             "output": "Tests/Math.html",
             "flags": ["--math"]


### PR DESCRIPTION
I don't know whether you accept cherrypicks, but this is a
cherrypick of https://github.com/hoedown/hoedown/commit/d8d37c3 .
The commit message for that is included at the bottom.

My end goal is to get this patch into a fork of hoextdown used in
some internal documentation tools.

---

To generate this change I did

$ curl -O https://github.com/hoedown/hoedown/commit/d8d37c3013dd957fb3dee6a31003baeae22d286e.patch
$ patch -p1 < d8d37c3013dd957fb3dee6a31003baeae22d286e.patch
$ make test

---

Comments in Markdown aren't really a thing, but they can come in super-useful.  As alluded to in the test-case, [MOE](https://github.com/google/MOE) can be used to sync between internally developed projects and open-source versions.  Part of that requires maintaining internal & external developer docs.  MOE directives in comments make that a lot easier, but if they can't appear in the middle of a bullet list that becomes a lot harder.

---

src/document.c recognizes `<!--...-->` style comments as a standalone block.

src/smarty_pants.c seems to recognize them anywhere though I haven't tested.
## 

This adds a test-case and tweaks document.c to copy HTML comments over
the same way it copies tags over.

The HTML comment recognizing code is a bit of a copy/paste job from
`parse_htmlblock` but that version does a bunch of extra work.  I can
factor out the common code if you'd like.
