### PR TITLE
Add a multiline table extension, controlled by a flag.

### DIFF
--- a/bin/hoedown.c
+++ b/bin/hoedown.c
@@ -41,6 +41,7 @@ static struct extension_category_info categories_info[] = {
 
 static struct extension_info extensions_info[] = {
 	{HOEDOWN_EXT_TABLES, "tables", "Parse PHP-Markdown style tables."},
+	{HOEDOWN_EXT_MULTILINE_TABLES, "multiline-tables", "Parse continuation-style multiline tables (only has an effect if --tables is also used)."},
 	{HOEDOWN_EXT_FENCED_CODE, "fenced-code", "Parse fenced code blocks."},
 	{HOEDOWN_EXT_FOOTNOTES, "footnotes", "Parse footnotes."},
 

--- a/src/document.c
+++ b/src/document.c
@@ -2690,6 +2690,53 @@ parse_htmlblock(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t
 	return tag_end;
 }
 
+/* Common function to parse table main rows and continued rows. */
+static size_t
+parse_table_cell_line(
+		hoedown_buffer *ob,
+		uint8_t *data,
+		size_t size,
+		size_t offset,
+		char separator,
+		int is_continuation) {
+	size_t pos, line_end, cell_start, cell_end, len;
+
+	pos = offset;
+
+	while (pos < size && _isspace(data[pos])) pos++;
+
+	cell_start = pos;
+
+	line_end = pos;
+	while (line_end < size && data[line_end] != '\n') line_end++;
+	len = find_emph_char(data + pos, line_end - pos, separator);
+
+	/* Two possibilities for len == 0:
+	   1) No more separator char found in the current line.
+	   2) The next separator is right after the current one, i.e. empty cell.
+	   For case 1, we skip to the end of line; for case 2 we just continue.
+	*/
+	if (len == 0 && pos < size && data[pos] != separator) {
+		while (pos + len < size && data[pos + len] != '\n') len++;
+	}
+	pos += len;
+
+	cell_end = pos - 1;
+
+	while (cell_end > cell_start && _isspace(data[cell_end]))
+		cell_end--;
+
+	/* If this isn't the first line of the cell, add a new line before the
+	   extra cell contents, to separate them (and make backslash linebreaks
+	   work).
+	*/
+	if (is_continuation) hoedown_buffer_putc(ob, '\n');
+
+	hoedown_buffer_put(ob, data + cell_start, 1 + cell_end - cell_start);
+
+	return pos - offset;
+}
+
 static void
 parse_table_row(
 	hoedown_buffer *ob,
@@ -2697,10 +2744,11 @@ parse_table_row(
 	uint8_t *data,
 	size_t size,
 	size_t columns,
+	size_t rows,
 	hoedown_table_flags *col_data,
 	hoedown_table_flags header_flag)
 {
-	size_t i = 0, col, len;
+	size_t i = 0, col;
 	hoedown_buffer *row_work = 0;
 
 	if (!doc->md.table_cell || !doc->md.table_row)
@@ -2708,39 +2756,60 @@ parse_table_row(
 
 	row_work = newbuf(doc, BUFFER_SPAN);
 
+	/* skip optional first pipe */
 	if (i < size && data[i] == '|')
 		i++;
 
 	for (col = 0; col < columns && i < size; ++col) {
-		size_t cell_start, cell_end;
+		size_t pos, extra_rows_in_cell;
+		hoedown_buffer *cell_content;
 		hoedown_buffer *cell_work;
 
+		/* cell_content is the text that is inline parsed into cell_work. It
+		   consists of the values of this cell from each row, concatenated and
+		   separated by new lines.
+		*/
+		cell_content = newbuf(doc, BUFFER_SPAN);
 		cell_work = newbuf(doc, BUFFER_SPAN);
 
-		while (i < size && _isspace(data[i]))
-			i++;
+		i += parse_table_cell_line(cell_content, data, size, i, '|', 0 /* is_contination */);
 
-		cell_start = i;
+		/* Add extra rows of the cell. This only occurs if rows is greater than 0,
+		   which only happens when multiline tables are enabled.
 
-		len = find_emph_char(data + i, size - i, '|');
-
-		/* Two possibilities for len == 0:
-		   1) No more pipe char found in the current line.
-		   2) The next pipe is right after the current one, i.e. empty cell.
-		   For case 1, we skip to the end of line; for case 2 we just continue.
+		   Each extra row is a colon, followed by cell contents for the continued
+		   row, separated by colons.
 		*/
-		if (len == 0 && i < size && data[i] != '|')
-			len = size - i;
-		i += len;
+		extra_rows_in_cell = rows - 1;
+		pos = i;
+		while (extra_rows_in_cell > 0 && pos < size) {
+			size_t c;
 
-		cell_end = i - 1;
+			/* seek to the end of the current row */
+			while (pos < size && data[pos] != '\n') {
+				pos++;
+			}
 
-		while (cell_end > cell_start && _isspace(data[cell_end]))
-			cell_end--;
+			/* skip new line and leading colon */
+			pos += 2;
 
-		parse_inline(cell_work, doc, data + cell_start, 1 + cell_end - cell_start);
+			/* seek to the beginning of the correct column on the continuation line */
+			for (c = 0; c < col; c++) {
+				while (pos < size && (is_escaped(data, pos) || data[pos] != ':'))
+					pos++;
+				pos++;  /* skip colon */
+			}
+
+			parse_table_cell_line(cell_content, data, size, pos, ':', 1 /* is_contination */);
+
+			extra_rows_in_cell--;
+		}
+
+		parse_inline(cell_work, doc, cell_content->data, cell_content->size);
+
 		doc->md.table_cell(row_work, cell_work, col_data[col] | header_flag, &doc->data);
 
+		popbuf(doc, BUFFER_SPAN);
 		popbuf(doc, BUFFER_SPAN);
 		i++;
 	}
@@ -2765,8 +2834,9 @@ parse_table_header(
 	size_t *columns,
 	hoedown_table_flags **column_data)
 {
-	int pipes;
+	int pipes, rows;
 	size_t i = 0, col, header_end, under_end;
+	hoedown_buffer *header_contents = 0;
 
 	pipes = 0;
 	while (i < size && data[i] != '\n') {
@@ -2811,8 +2881,61 @@ parse_table_header(
 	if (pipes < 0)
 		return 0;
 
+	/* header_contents will have the lines of the header copied into it, and then
+	   is passed to parse_table_row. We need a separate buffer to avoid passing
+	   the attribute to parse_table_row.
+	*/
+	header_contents = newbuf(doc, BUFFER_SPAN);
+	hoedown_buffer_put(header_contents, data, header_end);
+
 	*columns = pipes + 1;
 	*column_data = hoedown_calloc(*columns, sizeof(hoedown_table_flags));
+
+	/* If the multiline table extension is enabled, check the next lines for
+	   continuation markers, to find the number of text rows that make up this
+	   logical row, and copy the contents of each row to header_contents,
+	   separated by new lines.
+	*/
+	rows = 1;
+	if ((doc->ext_flags & HOEDOWN_EXT_MULTILINE_TABLES) != 0) {
+		while (i < size) {
+			size_t j = i + 1;
+			int colons = 0;
+
+			/* Require that the continuation line starts with a colon */
+			if (j >= size || data[j] != ':') break;
+			/* Skip the leading colon to match the pipe counting behavior above */
+			j++;
+
+			/* Require that the continuation line start with ": ", to
+			   distinguish from ":-" which could start a left-aligned header
+			   bar.
+			*/
+			if (j >= size || data[j] != ' ') break;
+
+			while (j < size && data[j] != '\n') {
+				j++;
+				if (!is_escaped(data, j) && data[j] == ':')
+					colons++;
+			}
+
+			/* Allow a trailing colon to match the pipe counting behavior above */
+			if (!is_escaped(data, j - 1) && data[j - 1] == ':')
+				colons--;
+
+			if (colons != pipes) break;
+
+			hoedown_buffer_putc(header_contents, '\n');
+			/* data[i] is the previous new line, and data[j] is the next new
+			   line. This copies all the text between the new lines.
+			 */
+			hoedown_buffer_put(header_contents, data + i + 1, j - i - 1);
+
+			rows++;
+			i = j;
+			header_end = j;
+		}
+	}
 
 	/* Parse the header underline */
 	i++;
@@ -2855,16 +2978,23 @@ parse_table_header(
 		i++;
 	}
 
-	if (col < *columns)
+	if (col < *columns) {
+		/* clean up header_contents */
+		popbuf(doc, BUFFER_SPAN);
 		return 0;
+	}
 
 	parse_table_row(
-		ob, doc, data,
-		header_end,
+		ob, doc, header_contents->data,
+		header_contents->size,
 		*columns,
+		rows,
 		*column_data,
 		HOEDOWN_TABLE_HEADER
 	);
+
+	/* clean up header_contents */
+	popbuf(doc, BUFFER_SPAN);
 
 	return under_end + 1;
 }
@@ -2896,6 +3026,7 @@ parse_table(
 		while (i < size) {
 			size_t row_start;
 			int pipes = 0;
+			size_t rows = 1;
 
 			row_start = i;
 
@@ -2908,16 +3039,102 @@ parse_table(
 				break;
 			}
 
+			/* Don't count a leading pipe. */
+			if (data[row_start] == '|')
+				pipes--;
+
+			/* Don't count a trailing pipe. */
+			if (data[i - 1] == '|')
+				pipes--;
+
+			/* If the multiline table extension is enabled, check the next
+			   lines for continuation markers, to find the number of text rows
+			   that make up this logical row.
+			*/
+			if ((doc->ext_flags & HOEDOWN_EXT_MULTILINE_TABLES) != 0) {
+				while (i < size) {
+					size_t j = i + 1;
+					int colons = 0;
+
+					/* Require that a continued row starts with a colon. */
+					if (j >= size || data[j] != ':') break;
+
+					/* Don't count leading colon for comparison to pipes. */
+					j++;
+
+					while (j < size && data[j] != '\n') {
+						j++;
+						if (!is_escaped(data, j) && data[j] == ':')
+							colons++;
+					}
+
+					/* Don't count a trailing colon for comparison to pipes. */
+					if (!is_escaped(data, j - 1) && data[j - 1] == ':')
+						colons--;
+
+					if (colons != pipes) break;
+
+					rows++;
+					i = j;
+				}
+			}
+
 			parse_table_row(
 				body_work,
 				doc,
 				data + row_start,
 				i - row_start,
 				columns,
+				rows,
 				col_data, 0
 			);
 
 			i++;
+
+			/* Skip an optional row separator, if it's there. */
+			if ((doc->ext_flags & HOEDOWN_EXT_MULTILINE_TABLES) != 0) {
+				/* Use j instead of i, and set i to j only if this is actually a row separator. */
+				size_t j = i, next_line_end = i, col;
+
+				/* Seek next_line_end to the position of the terminating new line. */
+				while (next_line_end < size && data[next_line_end] != '\n')
+					next_line_end++;
+
+				/* Skip leading pipe, if any. */
+				if (j < next_line_end && data[j] == '|')
+					j++;
+
+				/* Ensure that there are at least columns pipe/plus separated
+				   runs of dashes, each at least 3 long. The pipes may be
+				   padded with spaces, and the line may end in a pipe.
+				*/
+				for (col = 0; col < columns && j < next_line_end; col++) {
+					size_t dashes = 0;
+
+					while (j < next_line_end && data[j] == ' ')
+						j++;
+
+					while (j < next_line_end && data[j] == '-') {
+						j++;
+						dashes++;
+					}
+
+					while (j < next_line_end && data[j] == ' ')
+						j++;
+
+					if (j < next_line_end && data[j] != '|' && data[j] != '+')
+						break;
+
+					if (dashes < 3)
+						break;
+
+					j++;
+				}
+
+				/* Skip i past the row separator, if it was valid. */
+				if (col == columns)
+					i = next_line_end + 1;
+			}
 		}
 
 		if (doc->md.table_header)

--- a/src/document.h
+++ b/src/document.h
@@ -15,9 +15,11 @@ extern "C" {
  * CONSTANTS *
  *************/
 
+/* Next offset: 19 */
 typedef enum hoedown_extensions {
 	/* block-level extensions */
 	HOEDOWN_EXT_TABLES = (1 << 0),
+	HOEDOWN_EXT_MULTILINE_TABLES = (1 << 18),
 	HOEDOWN_EXT_FENCED_CODE = (1 << 1),
 	HOEDOWN_EXT_FOOTNOTES = (1 << 2),
 

--- a/test/Tests/extras/More_Tables.html
+++ b/test/Tests/extras/More_Tables.html
@@ -1,0 +1,203 @@
+<p>Minimal table:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Leading pipes only:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Trailing pipes only:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Leading and trailing pipes:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Extra padding:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>No padding:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Single column, leading pipe style:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Single column, trailing pipe style:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>With plus header separator:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo</th>
+      <th>bar</th>
+      <th>baz</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>oof</td>
+      <td>rab</td>
+      <td>zab</td>
+    </tr>
+    <tr>
+      <td>ofo</td>
+      <td>rba</td>
+      <td>bza</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/Tests/extras/More_Tables.text
+++ b/test/Tests/extras/More_Tables.text
@@ -1,0 +1,62 @@
+Minimal table:
+
+foo | bar | baz
+--- | --- | ---
+oof | rab | zab
+ofo | rba | bza
+
+Leading pipes only:
+
+| foo | bar | baz
+| --- | --- | ---
+| oof | rab | zab
+| ofo | rba | bza
+
+Trailing pipes only:
+
+foo | bar | baz |
+--- | --- | --- |
+oof | rab | zab |
+ofo | rba | bza |
+
+Leading and trailing pipes:
+
+| foo | bar | baz |
+| --- | --- | --- |
+| oof | rab | zab |
+| ofo | rba | bza |
+
+Extra padding:
+
+foo        |    bar      |    baz
+---    | ---    |     ---
+oof   |    rab  |    zab
+ofo    | rba  |   bza
+
+No padding:
+
+foo|bar|baz
+---|---|---
+oof|rab|zab
+ofo|rba|bza
+
+Single column, leading pipe style:
+
+| foo
+| ---
+| bar
+| baz
+
+Single column, trailing pipe style:
+
+foo |
+--- |
+bar |
+baz |
+
+With plus header separator:
+
+foo | bar | baz
+----+-----+----
+oof | rab | zab
+ofo | rba | bza

--- a/test/Tests/extras/Multiline_Table.html
+++ b/test/Tests/extras/Multiline_Table.html
@@ -1,0 +1,518 @@
+<p>Minimal header and body row continuation, with interior row and end row:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>With leading pipes:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>With trailing pipes only:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>With trailing colons only:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>With trailing pipes and colons:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Without body padding:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Without header padding (except mandatory leading space):</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Many continuation lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3 5 7</th>
+      <th>2 4 6 8</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9 11 13 15</td>
+      <td>10 12 14 16</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Single column:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>3 4</td>
+    </tr>
+    <tr>
+      <td>5 6</td>
+    </tr>
+    <tr>
+      <td>7</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Empty continued cells:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Empty then not empty continued cells:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Inside another element:</p>
+
+<ul>
+  <li>
+    <p>foo</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>1 3</th>
+          <th>2 4</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>5 7</td>
+          <td>6 8</td>
+        </tr>
+        <tr>
+          <td>9</td>
+          <td>10</td>
+        </tr>
+        <tr>
+          <td>11 13</td>
+          <td>12 14</td>
+        </tr>
+      </tbody>
+    </table>
+  </li>
+</ul>
+
+<p>Pipes on continued lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3 |</th>
+      <th>2 4 |</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7 |</td>
+      <td>6 | 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13 |</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Colons on regular lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1: 3</th>
+      <th>: 2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 : 7</td>
+      <td>:6 8</td>
+    </tr>
+    <tr>
+      <td>: 9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 :: 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Escaped colons on continued lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3:</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 : 7</td>
+      <td>6 8 :</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13 :</td>
+      <td>12 : 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Inline elements spanning multiple lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>5 7</strong></td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td><a href="/14">12</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Optional row separators:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Optional row separators with leading pipes:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Optional row separators with trailing pipes:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Optional row separators with leading and trailing pipes:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Optional row separators without padding:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12 14</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/Tests/extras/Multiline_Table.text
+++ b/test/Tests/extras/Multiline_Table.text
@@ -1,0 +1,252 @@
+Minimal header and body row continuation, with interior row and end row:
+
+1 | 2
+: 3 : 4
+--- | ---
+5 | 6
+: 7 : 8
+9 | 10
+11 | 12
+: 13 : 14
+
+With leading pipes:
+
+| 1 | 2
+: 3 : 4
+--- | ---
+| 5 | 6
+: 7 : 8
+| 9 | 10
+| 11 | 12
+: 13 : 14
+
+With trailing pipes only:
+
+| 1 | 2 |
+: 3 : 4
+--- | ---
+| 5 | 6 |
+: 7 : 8
+| 9 | 10 |
+| 11 | 12 |
+: 13 : 14
+
+With trailing colons only:
+
+| 1 | 2
+: 3 : 4 :
+--- | ---
+| 5 | 6
+: 7 : 8 :
+| 9 | 10
+| 11 | 12
+: 13 : 14 :
+
+With trailing pipes and colons:
+
+| 1 | 2 |
+: 3 : 4 :
+--- | ---
+| 5 | 6 |
+: 7 : 8 :
+| 9 | 10 |
+| 11 | 12 |
+: 13 : 14 :
+
+Without body padding:
+
+| 1 | 2 |
+: 3 : 4 :
+---|---
+|5|6|
+:7:8:
+|9|10|
+|11|12|
+:13:14:
+
+Without header padding (except mandatory leading space):
+
+|1|2|
+: 3:4:
+--- | ---
+| 5 | 6 |
+: 7 : 8 :
+| 9 | 10 |
+| 11 | 12 |
+: 13 : 14 :
+
+Many continuation lines:
+
+| 1   | 2   |
+: 3   : 4   :
+: 5   : 6   :
+: 7   : 8   :
+| --- | --- |
+| 9   | 10  |
+: 11  : 12  :
+: 13  : 14  :
+: 15  : 16  :
+
+Single column:
+
+| 1
+: 2
+| ---
+| 3
+: 4
+| ---
+| 5
+: 6
+| 7
+
+Empty continued cells:
+
+1 | 2
+: 3 : :
+--- | ---
+5 | 6
+: : 8
+9 | 10
+11 | 12
+: 13 : :
+
+Empty then not empty continued cells:
+
+1 | 2
+: 3 : :
+: : 4
+--- | ---
+5 | 6
+: : 8
+: 7 : :
+9 | 10
+11 | 12
+: 13 : :
+: : 14 :
+
+Inside another element:
+
+* foo
+
+  1 | 2
+  : 3 : 4
+  --- | ---
+  5 | 6
+  : 7 : 8
+  9 | 10
+  11 | 12
+  : 13 : 14
+
+Pipes on continued lines:
+
+1 | 2
+: 3 | : 4 |
+--- | ---
+5 | 6
+: 7 | : | 8
+9 | 10
+11 | 12
+: 13 | : 14
+
+Colons on regular lines:
+
+1: | : 2
+: 3 : 4
+--- | ---
+5 : | :6
+: 7 : 8
+: 9 | 10
+11 :: | 12
+: 13 : 14
+
+Escaped colons on continued lines:
+
+1 | 2
+: 3\: : 4
+--- | ---
+5 | 6
+: \: 7 : 8 \:
+9 | 10
+11 | 12
+: 13 \: : \: 14
+
+Inline elements spanning multiple lines:
+
+1 | 2
+: 3 : 4
+--- | ---
+**5 | 6
+: 7** : 8
+9 | 10
+11 | [12]
+: 13 : (/14)
+
+Optional row separators:
+
+1 | 2
+: 3 : 4
+--- | ---
+5 | 6
+: 7 : 8
+--- | ---
+9 | 10
+--- | ---
+11 | 12
+: 13 : 14
+--- | ---
+
+Optional row separators with leading pipes:
+
+1 | 2
+: 3 : 4
+| --- | ---
+5 | 6
+: 7 : 8
+| --- | ---
+9 | 10
+| --- | ---
+11 | 12
+: 13 : 14
+| --- | ---
+
+Optional row separators with trailing pipes:
+
+1 | 2
+: 3 : 4
+--- | --- |
+5 | 6
+: 7 : 8
+--- | --- |
+9 | 10
+--- | --- |
+11 | 12
+: 13 : 14
+--- | --- |
+
+Optional row separators with leading and trailing pipes:
+
+1 | 2
+: 3 : 4
+| --- | --- |
+5 | 6
+: 7 : 8
+| --- | --- |
+9 | 10
+| --- | --- |
+11 | 12
+: 13 : 14
+| --- | --- |
+
+Optional row separators without padding:
+
+1 | 2
+: 3 : 4
+|---|---|
+5 | 6
+: 7 : 8
+|---|---|
+9 | 10
+|---|---|
+11 | 12
+: 13 : 14
+|---|---|

--- a/test/Tests/extras/Special_Attribute_Multiline_Table.html
+++ b/test/Tests/extras/Special_Attribute_Multiline_Table.html
@@ -1,0 +1,44 @@
+<table id="table1">
+  <thead>
+    <tr>
+      <th>foo baz</th>
+      <th>bar bat</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>foo baz</td>
+      <td>bar bat</td>
+    </tr>
+  </tbody>
+</table>
+
+<table id="table2">
+  <thead>
+    <tr>
+      <th>foo baz</th>
+      <th>bar bat</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>foo baz</td>
+      <td>bar bat</td>
+    </tr>
+  </tbody>
+</table>
+
+<table id="table3">
+  <thead>
+    <tr>
+      <th>foo baz</th>
+      <th>bar bat</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>foo baz</td>
+      <td>bar bat</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/Tests/extras/Special_Attribute_Multiline_Table.text
+++ b/test/Tests/extras/Special_Attribute_Multiline_Table.text
@@ -1,0 +1,17 @@
+foo | bar {#table1}
+: baz : bat
+--- | ---
+foo | bar
+: baz : bat
+
+| foo | bar {#table2}
+: baz : bat
+| --- | ---
+| foo | bar
+: baz : bat
+
+| foo | bar | {#table3}
+: baz : bat :
+| --- | --- |
+| foo | bar |
+: baz : bat :

--- a/test/config.json
+++ b/test/config.json
@@ -117,6 +117,11 @@
             "flags": ["--tables"]
         },
         {
+            "input": "Tests/Table.text",
+            "output": "Tests/Table.html",
+            "flags": ["--tables", "--multiline-tables"]
+        },
+        {
             "input": "Tests/Images.text",
             "output": "Tests/Images.html",
             "flags": []
@@ -150,6 +155,16 @@
             "input": "Tests/extras/Special_Attribute_Escaped.text",
             "output": "Tests/extras/Special_Attribute_Escaped.html",
             "flags": ["--special-attribute"]
+        },
+        {
+            "input": "Tests/extras/Special_Attribute_Tables.text",
+            "output": "Tests/extras/Special_Attribute_Tables.html",
+            "flags": ["--special-attribute", "--tables", "--multiline-tables"]
+        },
+        {
+            "input": "Tests/extras/Special_Attribute_Multiline_Table.text",
+            "output": "Tests/extras/Special_Attribute_Multiline_Table.html",
+            "flags": ["--special-attribute", "--tables", "--multiline-tables"]
         },
         {
             "input": "Tests/extras/Tasks.text",
@@ -247,6 +262,21 @@
             "input": "Tests/extras/Link_Attributes.text",
             "output": "Tests/extras/Link_Attributes.html",
             "flags": ["--special-attribute", "--autolink", "--link-attributes-test"]
+        },
+        {
+            "input": "Tests/extras/Multiline_Table.text",
+            "output": "Tests/extras/Multiline_Table.html",
+            "flags": ["--tables", "--multiline-tables"]
+        },
+        {
+            "input": "Tests/extras/More_Tables.text",
+            "output": "Tests/extras/More_Tables.html",
+            "flags": ["--tables"]
+        },
+        {
+            "input": "Tests/extras/More_Tables.text",
+            "output": "Tests/extras/More_Tables.html",
+            "flags": ["--tables", "--multiline-tables"]
         },
         {
             "input": "Tests/context/Escaping.input",


### PR DESCRIPTION
(Further details here: https://github.com/jasharpe/hoextdown/wiki/Multiline-Table-Syntax-Extension)

In our usage of tables in Hoedown, we are struggling with very wide tables that
result because there is no mechanism for splitting cell contents across
multiple lines. This patch provides a flexible way of splitting cell contents
across multiple rows, with two basic components (continued rows and optional
row separators). These two components can be used together to accomplish the
task in a couple different styles, according to the discretion of the document
author.

We considered many types of syntax in developing this proposal, and settled on
this one as being the simplest, most lightweight extension of existing tables,
that still felt like good Markdown. Please see the following document for a
more complete justification of the choices made, along with many alternatives
syntaxes considered:
https://github.com/jasharpe/hoextdown/wiki/Multiline-Table-Syntax-Extension

Summary of changes (again, see the linked document above for details and
detailed examples):
- Introduce a new --multiline-tables flag to enable this extension.
- Single logical table rows (including the header) can be extended to multiple
  physical table rows by using a colon prefix and separators on subsequent
  lines ("continued rows"). For example:
  
  ```
  | foo | bar |
  : baz : bat :
  | --- | --- |
  | foo | bar |
  : baz : bat :
  | foo | bar |
  ```
  
  (Note that the special colon separator is necessary in order to make the row
  separators optional.)
- Rows may optionally be separated by row separator lines, in order to enhance
  readability when using continued rows. Small example (the benefit is more
  obvious for very large tables):
  
  ```
  | foo | bar |
  | --- | --- |
  | baz | bat |
  : baz : bat :
  : baz : bat :
  | --- | --- |
  | tab | cab |
  : tab : tab :
  | --- | --- |
  ```
- For now, rows that span multiple physical lines are still parsed with
  parse_inline - however, this could easily be extended in the future to
  parse_block should this be desired.

Summary of implementation changes:

For the most part, all significant changes have been guarded by the
--multiline-tables flag, however, a couple of minor changes were made outside
these sections (these will make more sense after reading the patch):
- Header row contents are copied to another buffer, and then to
  parse_table_row, in order to avoid passing in attributes to parse_table_row.
- Cell contents are copied to another buffer, and then sent to parse_inline, in
  order to concatenate the cell values from the main row and the following
  continued rows.

These changes should have a very minor affect on users who don't use
--multiline-tables.

I've introduced an extensive multiline table test suite to verify this change.
I've also added additional table tests (the existing ones were pretty sparse)
to make sure nothing is broken.

Please let me know if you have concerns about adding this as an extension in Hoextdown.

Thanks!

(Further details here: https://github.com/jasharpe/hoextdown/wiki/Multiline-Table-Syntax-Extension)
