### PR TITLE
Fix two multiline table bugs, with tests.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -3071,9 +3071,10 @@ parse_table(
 
 			row_start = i;
 
-			while (i < size && data[i] != '\n')
-				if (data[i++] == '|' && !is_backslashed(data, i))
-					pipes++;
+			while (i < size && data[i] != '\n') {
+				if (data[i] == '|' && !is_backslashed(data, i)) pipes++;
+				i++;
+			}
 
 			if (pipes == 0 || i == size) {
 				i = row_start;
@@ -3104,9 +3105,9 @@ parse_table(
 					j++;
 
 					while (j < size && data[j] != '\n') {
-						j++;
 						if (!is_backslashed(data, j) && data[j] == ':')
 							colons++;
+						j++;
 					}
 
 					/* Don't count a trailing colon for comparison to pipes. */

--- a/test/Tests/extras/Multiline_Table.html
+++ b/test/Tests/extras/Multiline_Table.html
@@ -236,6 +236,31 @@
   </tbody>
 </table>
 
+<p>Squished empty continued cells:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12</td>
+    </tr>
+  </tbody>
+</table>
+
 <p>Empty then not empty continued cells:</p>
 
 <table>
@@ -338,6 +363,31 @@
     <tr>
       <td>11 :: 13</td>
       <td>12 14</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Escaped pipes with continued lines:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>1 | 3</th>
+      <th>2 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5 7</td>
+      <td>6 | 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 | 13</td>
+      <td>12 | 14</td>
     </tr>
   </tbody>
 </table>

--- a/test/Tests/extras/Multiline_Table.text
+++ b/test/Tests/extras/Multiline_Table.text
@@ -110,6 +110,17 @@ Empty continued cells:
 11 | 12
 : 13 : :
 
+Squished empty continued cells:
+
+1 | 2
+: 3 ::
+--- | ---
+5 | 6
+:: 8
+9 | 10
+11 | 12
+: 13 ::
+
 Empty then not empty continued cells:
 
 1 | 2
@@ -157,6 +168,17 @@ Colons on regular lines:
 : 7 : 8
 : 9 | 10
 11 :: | 12
+: 13 : 14
+
+Escaped pipes with continued lines:
+
+1 \| | 2
+: 3 : 4
+--- | ---
+5 | 6 \|
+: 7 : 8
+9 | 10
+11 \| | 12 \|
 : 13 : 14
 
 Escaped colons on continued lines:


### PR DESCRIPTION
- Escaped pipes were erroneously being counted, meaning that it was impossible to have escaped pipes on the first line and then a continued row.
- Couldn't have adjacent colons on the continued row.

Both of these bugs are caused by incrementing counters in the wrong places.
