### PR TITLE
Add definition lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Extended the following functions.
 * [Fenced Script](#fenced-script)
 * [Script Tags](#script-tags)
 * [Meta Block](#meta-block)
+* [Definition Lists](#definition-lists)
 
 ## Special Attributes
 
@@ -213,4 +214,42 @@ becomes:
 --- Meta Block --
   author: user
   title: Readme markdown parser
+```
+
+## Definition Lists
+
+Add the `HOEXTDOWN_EXT_DEFINITION_LISTS` to Hoedown document flags.
+
+Add to support definition lists. Syntax follows [PHP Markdown Extra's syntax](https://michelf.ca/projects/php-markdown/extra/#def-list).
+
+```
+Term
+: Definition
+
+Term 1
+Term 2
+: Definition 2
+
+Term 3
+: Definition Line 1
+  Definition Line 2
+
+    Extra paragraphs need four spaces.
+```
+
+becomes:
+
+```
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+<dt>Term 1</dt>
+<dt>Term 2</dt>
+<dd>Definition 2</dd>
+<dt>Term 3</dt>
+<dd>
+<p>Definition Line 1 Definition Line 2</p>
+<p>Extra paragraphs need four spaces.</p>
+</dd>
+</dl>
 ```

--- a/bin/hoedown.c
+++ b/bin/hoedown.c
@@ -62,6 +62,8 @@ static struct extension_info extensions_info[] = {
 	{HOEDOWN_EXT_SPECIAL_ATTRIBUTE, "special-attribute", "Parse special attributes."},
 	{HOEDOWN_EXT_SCRIPT_TAGS, "script-tags", "Parse script tags <?..?>."},
 	{HOEDOWN_EXT_META_BLOCK, "meta-block", "Parse meta block <!--*..*-->."},
+
+	{HOEDOWN_EXT_DEFINITION_LISTS, "definition-lists", "Parse definition lists."},
 };
 
 static struct html_flag_info html_flags_info[] = {

--- a/src/document.h
+++ b/src/document.h
@@ -15,13 +15,14 @@ extern "C" {
  * CONSTANTS *
  *************/
 
-/* Next offset: 19 */
+/* Next offset: 20 */
 typedef enum hoedown_extensions {
 	/* block-level extensions */
 	HOEDOWN_EXT_TABLES = (1 << 0),
 	HOEDOWN_EXT_MULTILINE_TABLES = (1 << 18),
 	HOEDOWN_EXT_FENCED_CODE = (1 << 1),
 	HOEDOWN_EXT_FOOTNOTES = (1 << 2),
+	HOEDOWN_EXT_DEFINITION_LISTS = (1 << 19),
 
 	/* span-level extensions */
 	HOEDOWN_EXT_AUTOLINK = (1 << 3),
@@ -54,7 +55,8 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_TABLES |\
 	HOEDOWN_EXT_MULTILINE_TABLES |\
 	HOEDOWN_EXT_FENCED_CODE |\
-	HOEDOWN_EXT_FOOTNOTES )
+	HOEDOWN_EXT_FOOTNOTES |\
+	HOEDOWN_EXT_DEFINITION_LISTS )
 
 #define HOEDOWN_EXT_SPAN (\
 	HOEDOWN_EXT_AUTOLINK |\
@@ -80,7 +82,10 @@ typedef enum hoedown_list_flags {
 	HOEDOWN_LIST_ORDERED = (1 << 0),
 	HOEDOWN_LI_BLOCK = (1 << 1),	/* <li> containing block data */
 	HOEDOWN_LI_TASK = (1 << 2),
-	HOEDOWN_LI_END = (1 << 3)	/* internal list flag */
+	HOEDOWN_LI_END = (1 << 3),	/* internal list flag */
+	HOEDOWN_LIST_DEFINITION = (1 << 4),
+	HOEDOWN_LI_DT = (1 << 5),
+	HOEDOWN_LI_DD = (1 << 6)
 } hoedown_list_flags;
 
 typedef enum hoedown_table_flags {

--- a/src/html.c
+++ b/src/html.c
@@ -463,20 +463,26 @@ rndr_list(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffe
 
 	if (flags & HOEDOWN_LIST_ORDERED) {
 		HOEDOWN_BUFPUTSL(ob, "<ol");
-		if (attr && attr->size) {
-			rndr_attributes(ob, attr->data, attr->size, NULL, data);
-		}
-		HOEDOWN_BUFPUTSL(ob, ">\n");
+	} else if (flags & HOEDOWN_LIST_DEFINITION) {
+		HOEDOWN_BUFPUTSL(ob, "<dl");
 	} else {
 		HOEDOWN_BUFPUTSL(ob, "<ul");
-		if (attr && attr->size) {
-			rndr_attributes(ob, attr->data, attr->size, NULL, data);
-		}
-		HOEDOWN_BUFPUTSL(ob, ">\n");
+	}
+	if (attr && attr->size) {
+		rndr_attributes(ob, attr->data, attr->size, NULL, data);
 	}
 
+	HOEDOWN_BUFPUTSL(ob, ">\n");
+
 	if (content) hoedown_buffer_put(ob, content->data, content->size);
-	hoedown_buffer_put(ob, (const uint8_t *)(flags & HOEDOWN_LIST_ORDERED ? "</ol>\n" : "</ul>\n"), 6);
+
+	if (flags & HOEDOWN_LIST_ORDERED) {
+		HOEDOWN_BUFPUTSL(ob, "</ol>\n");
+	} else if (flags & HOEDOWN_LIST_DEFINITION) {
+		HOEDOWN_BUFPUTSL(ob, "</dl>\n");
+	} else {
+		HOEDOWN_BUFPUTSL(ob, "</ul>\n");
+	}
 }
 
 static void
@@ -489,7 +495,14 @@ rndr_listitem(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_b
 		while (size && content->data[size - 1] == '\n')
 			size--;
 
-		HOEDOWN_BUFPUTSL(ob, "<li");
+		if (*flags & HOEDOWN_LI_DD) {
+			HOEDOWN_BUFPUTSL(ob, "<dd");
+		} else  if (*flags & HOEDOWN_LI_DT) {
+			HOEDOWN_BUFPUTSL(ob, "<dt");
+		} else {
+			HOEDOWN_BUFPUTSL(ob, "<li");
+		}
+
 		if (attr && attr->size) {
 			rndr_attributes(ob, attr->data, attr->size, NULL, data);
 		}
@@ -518,9 +531,21 @@ rndr_listitem(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_b
 
 		hoedown_buffer_put(ob, content->data+prefix, size-prefix);
 	} else {
-		HOEDOWN_BUFPUTSL(ob, "<li>");
+		if (*flags & HOEDOWN_LI_DD) {
+			HOEDOWN_BUFPUTSL(ob, "<dd>");
+		} else if (*flags & HOEDOWN_LI_DT) {
+			HOEDOWN_BUFPUTSL(ob, "<dt>");
+		} else {
+			HOEDOWN_BUFPUTSL(ob, "<li>");
+		}
 	}
-	HOEDOWN_BUFPUTSL(ob, "</li>\n");
+	if (*flags & HOEDOWN_LI_DD) {
+		HOEDOWN_BUFPUTSL(ob, "</dd>\n");
+	} else if (*flags & HOEDOWN_LI_DT) {
+		HOEDOWN_BUFPUTSL(ob, "</dt>\n");
+	} else {
+		HOEDOWN_BUFPUTSL(ob, "</li>\n");
+	}
 }
 
 static void

--- a/test/Tests/extras/Definition_Lists.html
+++ b/test/Tests/extras/Definition_Lists.html
@@ -1,0 +1,382 @@
+<h2>Tight Definition List</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>A fruit</dd>
+  <dd>An apple</dd>
+
+  <dt>Orange</dt>
+  <dd>A citrus fruit</dd>
+  <dd>An orange</dd>
+</dl>
+
+<h2>Tight Definition Lists, Variant</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>A fruit</dd>
+  <dd>An apple</dd>
+
+  <dt>Orange</dt>
+  <dd>A citrus fruit</dd>
+  <dd>An orange</dd>
+</dl>
+
+<h2>Loose Definition List</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>
+    <p>A fruit</p>
+  </dd>
+  <dd>
+    <p>An apple</p>
+  </dd>
+
+  <dt>Orange</dt>
+  <dd>
+    <p>A citrus fruit</p>
+  </dd>
+  <dd>
+    <p>An orange</p>
+  </dd>
+</dl>
+
+<h2>Tight Tabs</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>A fruit</dd>
+  <dd>An apple</dd>
+
+  <dt>Orange</dt>
+  <dd>A citrus fruit</dd>
+  <dd>An orange</dd>
+</dl>
+
+<h2>Tight Tabs, Variant</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>A fruit</dd>
+  <dd>An apple</dd>
+
+  <dt>Orange</dt>
+  <dd>A citrus fruit</dd>
+  <dd>An orange</dd>
+</dl>
+
+<h2>Multiple Paragraphs</h2>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>
+    <p>An apples</p>
+    <p>An apple is an apple. Sometimes apples are necessary and sometimes not. Sometimes apples can also have <code>code</code> inside them for various reasons.</p>
+    <p>Situations involving apples include doctors and orchards.</p>
+  </dd>
+  <dd>
+    <p>A fruit</p>
+    <p>Fruits are fruity.</p>
+  </dd>
+
+  <dt>Orange</dt>
+  <dd>
+    <p>An orange</p>
+    <p>Oranges live in the city, unlike apples which live on orchards.
+    </p>
+    <p>Many skyscrapers bare oranges, but only some cities allow picking without a license.</p>
+  </dd>
+
+  <dt>Multiple Terms</dt>
+  <dt>Are also Allowed</dt>
+  <dt>No limits</dt>
+  <dd>
+    <p>Multiple implies more than one.</p>
+  </dd>
+</dl>
+
+<h2>Special Attributes</h2>
+
+<dl>
+  <dt id="apple" class="apple-class">Apples</dt>
+  <dd class="apples">
+    <p>A lifestyle.</p>
+    <p>The Apple lifestyle is a type of lifestyle commonly found in the lifestyle forests.</p>
+  </dd>
+  <dd class="fruit">
+    <p>A fruit.</p>
+    <p>Sometimes fruits are bought and then sold to fruit vendors who then buy and sell from other fruit vendors. Many fruit vendors buy fruit and sell them but sometimes the fruits are the ones buying vendors.</p>
+  </dd>
+
+  <dt class="apple-class">This is</dt>
+  <dt id="apple-id">Another</dt>
+  <dt>Three Things</dt>
+  <dt id="id" class="classy">Four Things</dt>
+  <dd>
+    <p>Orange</p>
+  </dd>
+</dl>
+
+<h2>Just colon things.</h2>
+  <p>: thing : a thing : another thing</p>
+  <p>Another test</p>
+
+<h2>of</h2>
+
+<dl>
+  <dt>Header interference</dt>
+  <dd>Check that your headers are on different bands before contacting support.</dd>
+</dl>
+
+<h2>Thing should not be</h2>
+  <p>: a list</p>
+
+<h2>but</h2>
+
+<dl>
+  <dt>this is</dt>
+  <dd>okay</dd>
+</dl>
+
+<h2>Unordered Lists</h2>
+
+<ul>
+  <li>Test Me</li>
+  <li>
+    <p>Nothing should interfere here</p>
+  </li>
+  <li>
+    <p>Definitely nothing</p>
+  </li>
+</ul>
+
+<h2>Ordered Lists</h2>
+
+<ol>
+  <li>Apples</li>
+  <li>Apples</li>
+  <li>
+    <p>Apples</p>
+  </li>
+  <li>
+    <p>Apples</p>
+  </li>
+</ol>
+
+<h2>Example in Readme</h2>
+
+<dl>
+  <dt>Term</dt>
+  <dd>Definition</dd>
+
+  <dt>Term 1</dt>
+  <dt>Term 2</dt>
+  <dd>Definition 2</dd>
+
+  <dt>Term 3</dt>
+  <dd>
+    <p>Definition Line 1 Definition Line 2</p>
+    <p>Extra paragraphs need four spaces.</p>
+  </dd>
+</dl>
+
+<h2>PHP Markdown Examples</h2>
+
+<dl>
+  <dt>Term 1</dt>
+  <dd>
+    <p>This is a definition with two paragraphs. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+    </p>
+    <p>Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+    </p>
+  </dd>
+  <dd>
+    <p>Second definition for term 1, also wrapped in a paragraph because of the blank line preceding it.</p>
+  </dd>
+
+  <dt>Term 2</dt>
+  <dd>
+    <p>This definition has a code block, a blockquote and a list.</p>
+    <pre><code>code block.
+</code></pre>
+    <blockquote>
+      <p>block quote on two lines.</p>
+    </blockquote>
+    <ol>
+      <li>first list item</li>
+      <li>second list item</li>
+    </ol>
+  </dd>
+</dl>
+
+<h2>Indentation Fun</h2>
+
+<ol>
+  <li>
+    <p>Ordered Item 1</p>
+    <dl>
+      <dt>Indented Term 1</dt>
+      <dd>
+        <p>Definition</p>
+      </dd>
+      <dd>
+        <p>Definition 2</p>
+      </dd>
+    </dl>
+  </li>
+
+  <li>
+    <dl>
+      <dt>Ordered Term 1</dt>
+      <dd>Definition 1</dd>
+      <dd>Definition 2</dd>
+    </dl>
+  </li>
+
+  <li>
+    <dl>
+      <dt>Ordered Term 2</dt>
+      <dt>Ordered Term 3</dt>
+      <dd>Definition 1</dd>
+    </dl>
+  </li>
+</ol>
+
+<h2>Blockquotes</h2>
+<blockquote>
+    <dl>
+        <dt>This line is a blockquote</dt>
+        <dd>and it is a definition list</dd>
+        <dt>This should also</dt>
+        <dt>Play rather</dt>
+        <dd>nicely</dd>
+    </dl>
+    <p>This is actually</p>
+    <blockquote>
+        <dl>
+            <dt>Pretty cool that it</dt>
+            <dt>Automagically works</dt>
+            <dd>Pretty cool, huh?</dd>
+        </dl>
+    </blockquote>
+    <dl>
+        <dt>Embedded List</dt>
+        <dd>This is a definition</dd>
+    </dl>
+    <blockquote>
+        <p>Another block quote</p>
+    </blockquote>
+    <dl>
+        <dt>Why would</dt>
+        <dd>&gt; Anyone do this? &gt; Is this reality?</dd>
+    </dl>
+</blockquote>
+<ol>
+    <li>In any case, that wasn't supported</li>
+    <li>&gt; Because this isn't supported and it isn't specced</li>
+    <li>Blockquotes are also &gt; Not supported &gt; Inside list items
+    </li>
+</ol>
+<dl>
+    <dt>This <em>is</em> a term</dt>
+    <dd>
+        <p>This will be a para</p>
+        <blockquote>
+            <p>a blockquote</p>
+        </blockquote>
+        <h1>A header</h1>
+    </dd>
+</dl>
+
+<h2>Tables</h2>
+
+<dl>
+  <dt>This is a definition list</dt>
+  <dd>
+    <p>Example11</p>
+    <table>
+      <thead>
+        <tr>
+          <th>11 13</th>
+          <th>12</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>15</td>
+          <td>16 18</td>
+        </tr>
+        <tr>
+          <td>19</td>
+          <td>110</td>
+        </tr>
+        <tr>
+          <td>111 113</td>
+          <td>112</td>
+        </tr>
+      </tbody>
+    </table>
+  </dd>
+  <dd>
+    <p>This is another definition</p>
+  </dd>
+  <dt>This is another term</dt>
+  <dd>
+    <p>Example22</p>
+    <table>
+      <thead>
+        <tr>
+          <th>21 23 25 27</th>
+          <th>22 24 26 28</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>29 211 213 215</td>
+          <td>210 212 214 216</td>
+        </tr>
+      </tbody>
+    </table>
+  </dd>
+  <dt>Term me more</dt>
+  <dt>Term me 3</dt>
+  <dd>
+    <p>Example33</p>
+  </dd>
+</dl>
+<table>
+  <thead>
+    <tr>
+      <th>1 3</th>
+      <th>2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>5</td>
+      <td>6 8</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>10</td>
+    </tr>
+    <tr>
+      <td>11 13</td>
+      <td>12</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>HTML and Codeblocks</h2>
+
+<p>hey whats this what about this</p>
+<div>is this html</div>
+<code>: maybe</code>
+<p>do this thing <code>: maybe</code>
+</p>
+<pre>
+<code>neither should
+: this really work
+</code>
+</pre>

--- a/test/Tests/extras/Definition_Lists.text
+++ b/test/Tests/extras/Definition_Lists.text
@@ -1,0 +1,301 @@
+## Tight Definition List
+
+Apple
+: A fruit
+: An apple
+
+Orange
+: A citrus fruit
+: An orange
+
+## Tight Definition Lists, Variant
+
+Apple
+
+: A fruit
+: An apple
+
+Orange
+
+: A citrus fruit
+: An orange
+
+## Loose Definition List
+
+Apple
+
+: A fruit
+
+: An apple
+
+Orange
+
+: A citrus fruit
+
+: An orange
+
+## Tight Tabs
+
+Apple
+
+:	A fruit
+:	An apple
+
+Orange
+
+:	A citrus fruit
+:	An orange
+
+## Tight Tabs, Variant
+
+Apple
+:	A fruit
+:	An apple
+
+Orange
+:	A citrus fruit
+:	An orange
+
+## Multiple Paragraphs
+
+Apple
+
+: An apples
+
+    An apple is an apple. Sometimes apples are necessary and sometimes not.
+    Sometimes apples can also have `code` inside them for various reasons.
+
+    Situations involving apples include doctors and orchards.
+
+: A fruit
+
+    Fruits are fruity.
+
+Orange
+
+: An orange
+
+    Oranges live in the city, unlike apples which live on orchards.
+
+    Many skyscrapers bare oranges, but only some cities allow picking without a license.
+
+Multiple Terms
+Are also Allowed
+No limits
+
+: Multiple implies more than one.
+
+## Special Attributes
+
+Apples {#apple .apple-class}
+
+: A lifestyle. {.apples}
+
+    The Apple lifestyle is a type of lifestyle commonly found in the lifestyle forests.
+
+: A fruit. {.fruit}
+
+    Sometimes fruits are bought and then sold to fruit vendors who then buy and sell from other fruit vendors.
+    Many fruit vendors buy fruit and sell them but sometimes the fruits are the ones buying vendors.
+
+This is {.apple-class}
+Another {#apple-id}
+Three Things
+Four Things {#id .classy}
+
+: Orange
+
+## Just colon things.
+
+: thing
+: a thing
+: another thing
+
+Another test
+## of
+Header interference
+: Check that your headers are on different bands before contacting support.
+
+Thing should not be
+---
+: a list
+
+but
+---
+this is
+: okay
+
+## Unordered Lists
+
++ Test Me
++ Nothing should interfere here
+
+- Definitely nothing
+
+## Ordered Lists
+
+1. Apples
+1. Apples
+1. Apples
+
+2. Apples
+
+## Example in Readme
+
+Term
+: Definition
+
+Term 1
+Term 2
+: Definition 2
+
+Term 3
+: Definition Line 1
+  Definition Line 2
+
+    Extra paragraphs need four spaces.
+
+## PHP Markdown Examples
+
+Term 1
+
+:   This is a definition with two paragraphs. Lorem ipsum 
+    dolor sit amet, consectetuer adipiscing elit. Aliquam 
+    hendrerit mi posuere lectus.
+
+    Vestibulum enim wisi, viverra nec, fringilla in, laoreet
+    vitae, risus.
+
+:   Second definition for term 1, also wrapped in a paragraph
+    because of the blank line preceding it.
+
+Term 2
+
+:   This definition has a code block, a blockquote and a list.
+
+        code block.
+
+    > block quote
+    > on two lines.
+
+    1.  first list item
+    2.  second list item
+
+## Indentation Fun
+
+1. Ordered Item 1
+
+   Indented Term 1
+
+   : Definition
+
+   : Definition 2
+
+2. Ordered Term 1
+   : Definition 1
+   : Definition 2
+
+3. Ordered Term 2
+   Ordered Term 3
+
+   : Definition 1
+
+## Blockquotes
+
+> This line is a blockquote
+: and it is a definition list
+
+> This should also
+> Play rather
+> : nicely
+
+> This is actually
+> > Pretty cool that it
+> > Automagically works
+> > : Pretty cool, huh?
+
+> Embedded List
+> : This is a definition
+>
+> > Another block quote
+
+> Why would
+> : > Anyone do this?
+> > Is this reality?
+
+1. In any case, that wasn't supported
+2. > Because this isn't supported and it isn't specced
+3. Blockquotes are also
+> Not supported
+> Inside list items
+
+This *is* a term
+
+: This will be a para
+
+  > a blockquote
+
+  # A header
+
+## Tables
+
+This is a definition list
+
+: Example11
+
+    11 | 12
+    : 13 : :
+    --- | ---
+    15 | 16
+    : : 18
+    19 | 110
+    111 | 112
+    : 113 : :
+
+
+: This is another definition
+
+This is another term
+: Example22
+
+  | 21   | 22   |
+  : 23   : 24   :
+  : 25   : 26   :
+  : 27   : 28   :
+  | --- | --- |
+  | 29   | 210  |
+  : 211  : 212  :
+  : 213  : 214  :
+  : 215  : 216  :
+
+Term me more
+Term me 3
+: Example33
+
+1 | 2
+: 3 : :
+--- | ---
+5 | 6
+: : 8
+9 | 10
+11 | 12
+: 13 : :
+
+## HTML and Codeblocks
+
+hey whats this
+what about this
+<div>is this html</div>
+```
+: maybe
+```
+
+do this thing
+```
+: maybe
+```
+
+```
+neither should
+: this really work
+```

--- a/test/config.json
+++ b/test/config.json
@@ -279,6 +279,11 @@
             "flags": ["--tables", "--multiline-tables"]
         },
         {
+            "input": "Tests/extras/Definition_Lists.text",
+            "output": "Tests/extras/Definition_Lists.html",
+            "flags": ["--definition-lists", "--tables", "--multiline-tables", "--fenced-code", "--special-attribute"]
+        },
+        {
             "input": "Tests/context/Escaping.input",
             "output": "Tests/context/Escaping.output",
             "flags": ["--context-test"]


### PR DESCRIPTION
Add support for definition lists, according to the spec at https://michelf.ca/projects/php-markdown/extra/#def-list.

It's been tested by adding the --definition-list tag to all the other tests, and none of them are affected. I've removed the added tag to make it cleaner, but can re-add to any of them.