### PR TITLE
Add special attributes for paragraphs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ At this time, special attribute blocks can be used with
 * links
 * images
 * tables
+* paragraphs
 
 For image and links, put the special attribute block immediately after the
 parenthesis containing the address:
@@ -82,6 +83,13 @@ definition line like this:
 ![img][linkref]
 
 [linkref]: url "optional title" {#id .class}
+```
+
+For paragraphs, put the special identifier `@paragraph` after the attribute.
+This helps prevent accidental parsing.
+
+```
+This is a paragraph. {@paragraph #id}
 ```
 
 ## Task Lists

--- a/src/context_test.c
+++ b/src/context_test.c
@@ -103,7 +103,7 @@ rndr_listitem(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_b
 }
 
 static void
-rndr_paragraph(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
+rndr_paragraph(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, const hoedown_renderer_data *data)
 {
 	int list_depth, blockquote_depth;
 

--- a/src/document.h
+++ b/src/document.h
@@ -140,7 +140,7 @@ struct hoedown_renderer {
 	void (*hrule)(hoedown_buffer *ob, const hoedown_renderer_data *data);
 	void (*list)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, hoedown_list_flags flags, const hoedown_renderer_data *data);
 	void (*listitem)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, hoedown_list_flags *flags, const hoedown_renderer_data *data);
-	void (*paragraph)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
+	void (*paragraph)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, const hoedown_renderer_data *data);
 	void (*table)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, const hoedown_renderer_data *data);
 	void (*table_header)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	void (*table_body)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);

--- a/src/html.c
+++ b/src/html.c
@@ -549,7 +549,7 @@ rndr_listitem(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_b
 }
 
 static void
-rndr_paragraph(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
+rndr_paragraph(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buffer *attr, const hoedown_renderer_data *data)
 {
 	hoedown_html_renderer_state *state = data->opaque;
 	size_t i = 0;
@@ -564,7 +564,14 @@ rndr_paragraph(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_
 	if (i == content->size)
 		return;
 
-	HOEDOWN_BUFPUTSL(ob, "<p>");
+	HOEDOWN_BUFPUTSL(ob, "<p");
+
+	if (attr && attr->size) {
+		rndr_attributes(ob, attr->data, attr->size, NULL, data);
+	}
+
+	HOEDOWN_BUFPUTSL(ob, ">");
+
 	if (state->flags & HOEDOWN_HTML_HARD_WRAP) {
 		size_t org;
 		while (i < content->size) {

--- a/test/Tests/extras/Special_Attribute_Lists.html
+++ b/test/Tests/extras/Special_Attribute_Lists.html
@@ -48,6 +48,12 @@
 </ul></li>
 </ul>
 
+<ol>
+  <li>Alpha</li>
+  <li>Beta</li>
+  <li>Gamma {@random #not-real}</li>
+</ol>
+
 <hr>
 
 <ol>

--- a/test/Tests/extras/Special_Attribute_Lists.text
+++ b/test/Tests/extras/Special_Attribute_Lists.text
@@ -29,6 +29,10 @@
         * Blue  {#3 .blue}
         {@list .class-list .level-3}
 
+1. Alpha
+2. Beta
+3. Gamma {@random #not-real}
+
 ---
 
 1. Blah:

--- a/test/Tests/extras/Special_Attribute_Paragraphs.html
+++ b/test/Tests/extras/Special_Attribute_Paragraphs.html
@@ -1,0 +1,23 @@
+<p id="id" class="class">Paragraph</p>
+
+<p id="id" class="class">Paragraph</p>
+
+<p id="id" class="class">Paragraph</p>
+
+<p>Preserve {@paragraph #id .class} this</p>
+
+<p id="id-2">Ignore this {@paragraph #id .class} but not this</p>
+
+<p>This is not processed {@paragraph #id}</p>
+
+<p>This is not processed {#id}</p>
+
+<p>This is not processed {@random #id}</p>
+
+<ul>
+<li>
+<p>Testing paragraphs</p>
+<p class="p">In loose lists</p>
+<p>This does not activate {@random .nop}</p>
+</li>
+</ul>

--- a/test/Tests/extras/Special_Attribute_Paragraphs.text
+++ b/test/Tests/extras/Special_Attribute_Paragraphs.text
@@ -1,0 +1,22 @@
+Paragraph {@paragraph #id .class}
+
+Paragraph {@paragraph  #id .class }
+
+Paragraph
+{@paragraph #id .class}
+
+Preserve {@paragraph #id .class} this
+
+Ignore this {@paragraph #id .class} but not this {@paragraph #id-2}
+
+This is not processed \{@paragraph #id\}
+
+This is not processed {#id}
+
+This is not processed {@random #id}
+
+* Testing paragraphs
+
+  In loose lists {@paragraph .p}
+
+  This does not activate {@random .nop}

--- a/test/config.json
+++ b/test/config.json
@@ -172,6 +172,11 @@
             "flags": ["--task", "--special-attribute"]
         },
         {
+            "input": "Tests/extras/Special_Attribute_Paragraphs.text",
+            "output": "Tests/extras/Special_Attribute_Paragraphs.html",
+            "flags": ["--special-attribute"]
+        },
+        {
             "input": "Tests/extras/Line_Continue.text",
             "output": "Tests/extras/Line_Continue.html",
             "flags": ["--line-continue"]


### PR DESCRIPTION
This change also forces the @list specifier for list-level attributes.
Before, any string could have been used and it would have been
interpreted as a list-level special attribute.

Paragraphs that need special attributes must have the @paragraph
identifier in the beginning of their special attributes. This was used
because it is very common in text to have brackets, and would lead to
false positives otherwise.