### PR TITLE
Allow for header ID in case of special attribute.

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -410,17 +410,25 @@ rndr_header(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_buf
 	if (ob->size)
 		hoedown_buffer_putc(ob, '\n');
 
+	hoedown_buffer *merged_attr = hoedown_buffer_new(sizeof(hoedown_buffer));
+
 	if (attr && attr->size) {
+		hoedown_buffer_put(merged_attr, attr->data, attr->size);
+	}
+	if ((state->flags & HOEDOWN_HTML_HEADER_ID) || (level <= state->toc_data.nesting_level)) {
+		hoedown_buffer_puts(merged_attr, " #");
+		rndr_header_id(merged_attr, content->data, content->size, 0, data);
+	}
+
+	if (merged_attr && merged_attr->size) {
 		hoedown_buffer_printf(ob, "<h%d", level);
-		rndr_attributes(ob, attr->data, attr->size, NULL, data);
+		rndr_attributes(ob, merged_attr->data, merged_attr->size, NULL, data);
 		hoedown_buffer_putc(ob, '>');
-	} else if ((state->flags & HOEDOWN_HTML_HEADER_ID) || (level <= state->toc_data.nesting_level)) {
-		hoedown_buffer_printf(ob, "<h%d id=\"", level);
-		rndr_header_id(ob, content->data, content->size, 0, data);
-		hoedown_buffer_puts(ob, "\">");
 	} else {
 		hoedown_buffer_printf(ob, "<h%d>", level);
 	}
+
+	hoedown_buffer_free(merged_attr);
 
 	if (content) hoedown_buffer_put(ob, content->data, content->size);
 	hoedown_buffer_printf(ob, "</h%d>\n", level);

--- a/test/Tests/extras/Header_ID.html
+++ b/test/Tests/extras/Header_ID.html
@@ -1,0 +1,5 @@
+<h1 id="test">Test</h1>
+
+<h1 id="title" class="not-title">Title</h1>
+
+<h1 id="is-title">Not Title</h1>

--- a/test/Tests/extras/Header_ID.text
+++ b/test/Tests/extras/Header_ID.text
@@ -1,0 +1,5 @@
+# Test
+
+# Title {.not-title}
+
+# Not Title {#is-title}

--- a/test/config.json
+++ b/test/config.json
@@ -242,6 +242,11 @@
             "output": "Tests/extras/Header_Empty_Attribute.html",
             "flags": ["--header-id", "--special-attribute"]
         },
+        {
+            "input": "Tests/extras/Header_ID.text",
+            "output": "Tests/extras/Header_ID.html",
+            "flags": ["--header-id", "--special-attribute"]
+        },
 
         {
             "input": "Tests/extras/Toc_Header_Empty.text",


### PR DESCRIPTION
Previously, the special attribute would override the header ID
extension. This change lets the two extensions play more nicely
together. If the special attribute string has an ID, it would override
the default header ID. If the special attribute string has no ID, then
the default header ID is used if the extension is turned on.