### PR TITLE
Add an option for an activation char for special attributes.

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -199,6 +199,7 @@ hoedown_document *hoedown_document_new(
 	const hoedown_renderer *renderer,
 	hoedown_extensions extensions,
 	size_t max_nesting,
+	uint8_t attr_activation,
 	hoedown_user_block user_block,
 	hoedown_buffer *meta
 ) __attribute__ ((malloc));

--- a/src/html.c
+++ b/src/html.c
@@ -215,12 +215,10 @@ rndr_blockcode(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buf
 		}
 		HOEDOWN_BUFPUTSL(ob, "<pre><code");
 		if (attr && attr->size) {
-			size_t len = 0;
 			hoedown_buffer *lang_class = hoedown_buffer_new(lang->size + 9);
-			while (len < lang->size && lang->data[len] != '{') len++;
-			if (len) {
+			if (lang->size) {
 				HOEDOWN_BUFPUTSL(lang_class, "language-");
-				escape_html(lang_class, lang->data, len);
+				escape_html(lang_class, lang->data, lang->size);
 				if (lang_class->data[lang_class->size-1] != ' ') {
 					hoedown_buffer_putc(lang_class, ' ');
 				}

--- a/test/Tests/extras/Special_Attribute_Activation.html
+++ b/test/Tests/extras/Special_Attribute_Activation.html
@@ -1,0 +1,103 @@
+<h1>Not {.activated}</h1>
+
+<h1 class="activated">Is</h1>
+
+<p>
+  This tests <a href="notreal.com">links</a>{.link-me} and
+<code>block code</code>{.code-me}
+</p>
+
+<p>
+  This tests <a href="notreal.com" class="link-me">links</a> and
+<code class="code-me">block code</code>
+</p>
+
+<ul>
+  <li>list {.do-nothing}</li>
+  <li class="do-something">list</li>
+</ul>
+
+<pre>
+<code class="language-{.codefence-me}">print "hello"
+</code>
+</pre>
+
+<pre>
+<code class="codefence-me">print "hello"
+</code>
+</pre>
+
+<h2>hello {.not-title}</h2>
+
+<h2 class="title">hello</h2>
+
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Age {.not-table}</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>Fred</td>
+<td>29</td>
+</tr>
+<tr>
+<td>Jim</td>
+<td>47</td>
+</tr>
+<tr>
+<td>Harry</td>
+<td>32</td>
+</tr>
+</tbody></table>
+
+<table class="table"><thead>
+<tr>
+<th>Name</th>
+<th>Age</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>Fred</td>
+<td>29</td>
+</tr>
+<tr>
+<td>Jim</td>
+<td>47</td>
+</tr>
+<tr>
+<td>Harry</td>
+<td>32</td>
+</tr>
+</tbody></table>
+
+<table>
+  <thead>
+    <tr>
+      <th>foo baz</th>
+      <th>bar {.not-table} bat</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>foo baz</td>
+      <td>bar bat</td>
+    </tr>
+  </tbody>
+</table>
+
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>foo baz</th>
+      <th>bar bat</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>foo baz</td>
+      <td>bar bat</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/Tests/extras/Special_Attribute_Activation.text
+++ b/test/Tests/extras/Special_Attribute_Activation.text
@@ -1,0 +1,49 @@
+# Not {.activated}
+
+# Is {: .activated}
+
+This tests [links](notreal.com){.link-me} and `block code`{.code-me}
+
+This tests [links](notreal.com){: .link-me} and `block code`{: .code-me}
+
+* list {.do-nothing}
+* list {:.do-something}
+
+```{.codefence-me}
+print "hello"
+```
+
+```{:.codefence-me}
+print "hello"
+```
+
+hello {.not-title}
+-----
+
+hello {:.title}
+-----
+
+Name    |  Age {.not-table}
+--------|------
+Fred    |   29
+Jim     |   47
+Harry   |   32
+
+
+Name    |  Age  {:.table}
+--------|------
+Fred    |   29
+Jim     |   47
+Harry   |   32
+
+foo | bar {.not-table}
+: baz : bat
+--- | ---
+foo | bar
+: baz : bat
+
+foo | bar {:.table}
+: baz : bat
+--- | ---
+foo | bar
+: baz : bat

--- a/test/Tests/extras/Special_Attribute_FencedCode.html
+++ b/test/Tests/extras/Special_Attribute_FencedCode.html
@@ -18,3 +18,6 @@
 
 <pre><code id="id-5" class="class-5">code test
 </code></pre>
+
+<pre><code id="id-6" class="language-a class-6">code test
+</code></pre>

--- a/test/Tests/extras/Special_Attribute_FencedCode.text
+++ b/test/Tests/extras/Special_Attribute_FencedCode.text
@@ -26,3 +26,8 @@ code test
 ``` {#id-5 .class-5}
 code test
 ```
+
+
+``` a b {#id-6 .class-6}
+code test
+```

--- a/test/config.json
+++ b/test/config.json
@@ -127,6 +127,11 @@
             "flags": []
         },
         {
+            "input": "Tests/extras/Special_Attribute_Activation.text",
+            "output": "Tests/extras/Special_Attribute_Activation.html",
+            "flags": ["--special-attribute", "--fenced-code", "--tables", "--multiline-tables", "-a", ":"]
+        },
+        {
             "input": "Tests/extras/Special_Attribute_Headers.text",
             "output": "Tests/extras/Special_Attribute_Headers.html",
             "flags": ["--special-attribute"]


### PR DESCRIPTION
Sometimes, the current special attribute model can lead to accidental
attributes made with brackets. The behavior is currently not
configurable. This change allows the special attribute to require a
specified char in front of special attributes, to make it harder to make
it accidental.

For example, if the char was set to `:`, then `# h {:.class}` would turn
into `<h1 class="class">h</h1>` but `# h {.class}` would not.