### PR TITLE
Fix issue where inline special attributes were fine with spaces.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -608,10 +608,6 @@ parse_inline(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t si
 static size_t parse_inline_attributes(uint8_t *data, size_t size, struct hoedown_buffer *attr, uint8_t attr_activation)
 {
 	size_t attr_start, i = 0;
-	/* skip leading whitespace */
-	while (i < size && _isspace(data[i])) {
-		i++;
-	}
 
 	if (data[i] == '{' && (!attr_activation || (i + 1 < size && data[i + 1] == attr_activation))) {
 		attr_start = i + 1;

--- a/test/Tests/extras/Special_Attribute_Codespan.html
+++ b/test/Tests/extras/Special_Attribute_Codespan.html
@@ -1,0 +1,3 @@
+<p>Test that <code>space</code> {.breaks}</p>
+
+<p>Test that <code class="does-not-break">nospace</code></p>

--- a/test/Tests/extras/Special_Attribute_Codespan.text
+++ b/test/Tests/extras/Special_Attribute_Codespan.text
@@ -1,0 +1,3 @@
+Test that `space` {.breaks}
+
+Test that `nospace`{.does-not-break}

--- a/test/Tests/extras/Special_Attribute_Links.html
+++ b/test/Tests/extras/Special_Attribute_Links.html
@@ -6,6 +6,8 @@
 
 <p>This is the <a href="/simple" class="example">simple case</a></p>
 
+<p>This is the [simple case with space] {.example}</p>
+
 <p>This is the <a href="/simple" id="link">simple case</a></p>
 
 <p>This is the <a href="/simple" id="about" class="abount">simple case</a></p>

--- a/test/Tests/extras/Special_Attribute_Links.text
+++ b/test/Tests/extras/Special_Attribute_Links.text
@@ -6,6 +6,8 @@ See my [About](/about/){#about .about} page for details.
 
 This is the [simple case]{.example}
 
+This is the [simple case with space] {.example}
+
 This is the [simple case]{#link}
 
 This is the [simple case]{#about .abount}

--- a/test/config.json
+++ b/test/config.json
@@ -152,6 +152,11 @@
             "flags": ["--special-attribute", "--fenced-code"]
         },
         {
+            "input": "Tests/extras/Special_Attribute_Codespan.text",
+            "output": "Tests/extras/Special_Attribute_Codespan.html",
+            "flags": ["--special-attribute"]
+        },
+        {
             "input": "Tests/extras/Special_Attribute_Tables.text",
             "output": "Tests/extras/Special_Attribute_Tables.html",
             "flags": ["--special-attribute", "--tables"]


### PR DESCRIPTION
The behavior before the changes to the special attributes was that
spaces were not allowed. This allows for not accidentally making content
inside {brackets} disappear. This readds that requirement that spaces
are not allowed between a codespan or a link and their special
attributes.