### PR TITLE
Update is_atxheader to use the parse_inline_attributes function.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1839,11 +1839,9 @@ is_atxheader(hoedown_document *doc, uint8_t *data, size_t size)
 			if (begin > 0 && !is_empty_all(data + level, begin)) {
 				return 1;
 			}
-			/* check for special attributes after the level */
+			/* check for special attributes after the # */
 			begin += level;
-			if (parse_inline_attributes(data + begin, len - begin, NULL, doc->attr_activation) > 0) {
-				return 0;
-			}
+			return !parse_inline_attributes(data + begin, len - begin, NULL, doc->attr_activation);
 		}
 	}
 

--- a/src/document.c
+++ b/src/document.c
@@ -1834,11 +1834,15 @@ is_atxheader(hoedown_document *doc, uint8_t *data, size_t size)
 	if (len && (doc->ext_flags & HOEDOWN_EXT_SPECIAL_ATTRIBUTE)) {
 		p = memchr(data + level, '{', len);
 		if (p) {
+			/* get number of characters from # to { */
 			begin = (p - data) - level;
-			if (memchr(data + begin, '}', len - begin)) {
-				if (!begin || is_empty_all(data + level, begin)) {
-					return 0;
-				}
+			if (begin > 0 && !is_empty_all(data + level, begin)) {
+				return 1;
+			}
+			/* check for special attributes after the level */
+			begin += level;
+			if (parse_inline_attributes(data + begin, len - begin, NULL, doc->attr_activation) > 0) {
+				return 0;
 			}
 		}
 	}

--- a/test/Tests/extras/Special_Attribute_Activation.html
+++ b/test/Tests/extras/Special_Attribute_Activation.html
@@ -1,5 +1,9 @@
 <h1>Not {.activated}</h1>
 
+<h1>{.activated}</h1>
+
+<h1>{{.activated}} content</h1>
+
 <h1 class="activated">Is</h1>
 
 <p>

--- a/test/Tests/extras/Special_Attribute_Activation.text
+++ b/test/Tests/extras/Special_Attribute_Activation.text
@@ -1,5 +1,9 @@
 # Not {.activated}
 
+# {.activated}
+
+# {{.activated}} content
+
 # Is {: .activated}
 
 This tests [links](notreal.com){.link-me} and `block code`{.code-me}


### PR DESCRIPTION
This fixes a case where using the activation char for attributes would not work inside a header, because the function uses its own { checking.