### PR TITLE
Fix issue with consecutive HTML endings not being parsed.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2790,7 +2790,7 @@ htmlblock_find_end_strict(
 		if (i == mark) return 0;
 
 		mark += htmlblock_find_end(tag, tag_len, doc, data + mark, i - mark);
-		if (mark == i && (is_empty(data + i, size - i) || data[i] == '<' || i >= size)) break;
+		if (mark == i && (is_empty(data + i, size - i) || (i + 1 < size && data[i] == '<' && data[i + 1] != '/') || i >= size)) break;
 	}
 
 	return i;

--- a/src/document.c
+++ b/src/document.c
@@ -2771,7 +2771,7 @@ htmlblock_find_end(
 }
 
 /* htmlblock_find_end_strict • try to find end of HTML block in strict mode */
-/*	(it must be an unindented line, and have a blank line afterwads) */
+/*	(it must have a blank line or a new HTML tag afterwards) */
 /*	returns the length on match, 0 otherwise */
 static size_t
 htmlblock_find_end_strict(

--- a/test/Tests/extras/HTML_Nested.html
+++ b/test/Tests/extras/HTML_Nested.html
@@ -1,0 +1,7 @@
+<div>
+  <div>text
+  </div>
+</div>
+<div>
+  *dont parse*
+</div>

--- a/test/Tests/extras/HTML_Nested.text
+++ b/test/Tests/extras/HTML_Nested.text
@@ -1,0 +1,7 @@
+<div>
+  <div>text
+  </div>
+</div>
+<div>
+  *dont parse*
+</div>

--- a/test/config.json
+++ b/test/config.json
@@ -327,6 +327,10 @@
             "output": "Tests/extras/issues_47.html"
         },
         {
+            "input": "Tests/extras/HTML_Nested.text",
+            "output": "Tests/extras/HTML_Nested.html"
+        },
+        {
             "input": "Tests/context/Escaping.input",
             "output": "Tests/context/Escaping.output",
             "flags": ["--context-test"]


### PR DESCRIPTION
With the recent changes, old HTML that followed the pattern

<div>
  <div>
  </div>
</div>

now have the last </div> parsed as a paragraph. The previous behavior started a new HTML block if it finds a line that starts with <. This isn't very reliable, so I added a check to make sure it isn't "</". It's still fragile, but less so.