### PR TITLE
Avoid out-of-bounds read and compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter
+CFLAGS = -g -O3 -std=c99 -D_DEFAULT_SOURCE -pedantic -Wall -Wextra -Wno-unused-parameter
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 LIBDIR = $(PREFIX)/lib

--- a/src/document.c
+++ b/src/document.c
@@ -1806,13 +1806,10 @@ is_codefence(uint8_t *data, size_t size, size_t *width, uint8_t *chr)
 	if (n < 3)
 		return 0;
 
-	for (j = i; j < size; ++j) {
+	for (j = i; j < size && data[j] != '\n'; ++j) {
 		if (data[j] == c) {
 			/* Avoid parsing codespan as fence. */
 			return 0;
-		}
-		if (data[j] == '\n') {
-			break;
 		}
 	}
 

--- a/src/document.c
+++ b/src/document.c
@@ -1471,7 +1471,7 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 			}
 			else if (data[i] == ')') {
 				if (nb_p == 0) break;
-				else nb_p--; i++;
+				nb_p--; i++;
 			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}
@@ -2415,7 +2415,8 @@ parse_listitem(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t 
 		end++;
 
 	if (doc->ext_flags & HOEDOWN_EXT_FENCED_CODE) {
-		if (fence_pre = is_codefence(data + beg, end - beg, &len, NULL)) {
+		fence_pre = is_codefence(data + beg, end - beg, &len, NULL);
+		if (fence_pre) {
 			in_fence = 1;
 			fence_pre = fence_pre + beg - len;
 		}

--- a/src/document.c
+++ b/src/document.c
@@ -1789,8 +1789,10 @@ is_codefence(uint8_t *data, size_t size, size_t *width, uint8_t *chr)
 	if (data[2] == ' ') { i++; } } }
 
 	/* looking at the hrule uint8_t */
+	if (i + 2 >= size)
+		return 0;
 	c = data[i];
-	if (i + 2 >= size || !(c=='~' || c=='`'))
+	if (!(c=='~' || c=='`'))
 		return 0;
 
 	/* the fence must be that same character */

--- a/src/document.c
+++ b/src/document.c
@@ -3345,7 +3345,7 @@ parse_table(
 
 		while (i < size) {
 			size_t row_start;
-			int pipes = 0;
+			size_t pipes = 0;
 			size_t rows = 1;
 
 			row_start = i;
@@ -3375,7 +3375,7 @@ parse_table(
 			if ((doc->ext_flags & HOEDOWN_EXT_MULTILINE_TABLES) != 0) {
 				while (i < size) {
 					size_t j = i + 1;
-					int colons = 0;
+					size_t colons = 0;
 
 					/* Require that a continued row starts with a colon. */
 					if (j >= size || data[j] != ':') break;
@@ -3397,7 +3397,7 @@ parse_table(
 					 * from `columns`. In this case, `parse_table_row` will add empty
 					 * cells. However, the code does not work in the multi-line case, so
 					 * we require the right number of columns. */
-					if (colons != pipes || colons != columns - 1) break;
+					if (colons != pipes || colons + 1 != columns) break;
 
 					rows++;
 					i = j;


### PR DESCRIPTION
This removes a potential read beyond the end of the buffer, which was introduced in 08b0f2c3c76098cb34146a20e0d6228d2a2ccf09 and became more likely to trigger due to the additional call to `is_codefence` introduced in 9ced48b4880d2ed55415b7ddd43e36030462abaa.

Apart from this I am tackling the huge list of compiler warnings that I get on my system (Debian testing, libc6 2.30, gcc 4:9.2.1). Some of them are minor but annoying, for example a huge list of signedness mismatches for string literal arguments. Some of them are more serious, such as implicitly defined functions. With these changes, the code compiles for me without a single warning.

I'm also including a minor readability improvement suggested by Jonas Wagner.