### PR TITLE
Restore attribute handling with empty block_id

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -697,13 +697,12 @@ static size_t parse_attributes(uint8_t *data, size_t size, struct hoedown_buffer
 				}
 				/* it might have matched only the first portion of block_id; make sure
 				 * there's no more to it here */
-				if (*block_id || (begin < end && data[begin] != ' ')) {
+				if (*block_id) {
 					return len;
 				}
-			} else {
-				while (begin < end && data[begin] != ' ') {
-					begin++;
-				}
+			}
+			if (begin < end && data[begin] != ' ') {
+				return len;
 			}
 			if (block_attr) {
 				if (block_attr->size) {

--- a/test/Tests/extras/Special_Attribute_CodeBlock.html
+++ b/test/Tests/extras/Special_Attribute_CodeBlock.html
@@ -1,0 +1,19 @@
+<p>This is a space-indented code block.</p>
+
+<pre><code>{
+  /** JavaDoc with a {@link #somewhere}
+   */
+}
+</code></pre>
+
+<p>The link is <em>not</em> an extended attribute!</p>
+
+<pre><code class="codesample">{
+  /** Code with attribute
+   */
+}
+</code></pre>
+
+<p>The above <em>is</em> an extended attribute, at least for now.
+See <a href="https://github.com/kjdev/hoextdown/issues/62">#62</a> for a discussion about
+whether this kind of syntax should be supported.</p>

--- a/test/Tests/extras/Special_Attribute_CodeBlock.text
+++ b/test/Tests/extras/Special_Attribute_CodeBlock.text
@@ -1,0 +1,17 @@
+This is a space-indented code block.
+
+    {
+      /** JavaDoc with a {@link #somewhere}
+       */
+    }
+
+The link is *not* an extended attribute!
+
+    {
+      /** Code with attribute
+       */
+    } {@ .codesample }
+
+The above *is* an extended attribute, at least for now.
+See [#62](https://github.com/kjdev/hoextdown/issues/62) for a discussion about
+whether this kind of syntax should be supported.

--- a/test/config.json
+++ b/test/config.json
@@ -167,6 +167,11 @@
             "flags": ["--special-attribute", "--fenced-code"]
         },
         {
+            "input": "Tests/extras/Special_Attribute_CodeBlock.text",
+            "output": "Tests/extras/Special_Attribute_CodeBlock.html",
+            "flags": ["--special-attribute"]
+        },
+        {
             "input": "Tests/extras/Special_Attribute_Codespan.text",
             "output": "Tests/extras/Special_Attribute_Codespan.html",
             "flags": ["--special-attribute"]


### PR DESCRIPTION
Commit 08c3e4f48b2cf137f1848e789d6b5d21075b4e65 had been aiming to be a semantic no-op in its attribute handling. But I had missed the fact that with empty block_id any characters between `'@'` and `' '` would cause the match to fail. This can be important e.g. when there are JavaDoc comments in code as these are likely to start with `"{@"`.

The sequence `"{@ "` can be used to introduce an extended comment inside a code block. I'm not sure whether that's [a bug or a feature](https://github.com/kjdev/hoextdown/issues/62), so I'm documenting it in the test case for now, so that any change in behavior there will at least be deliberate.