### PR TITLE
Fix: Prevent pointer underflow in autolink rewind loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,25 @@ test-issues-65: libhoedown.so
 	$(CXX) -fsanitize=address -g -O0 -o ./test/issues_65.out test/issues_65.cpp -I./src -L./ -Wl,-rpath,./ -lhoedown
 	./test/issues_65.out
 
+ISSUE67_SRC = \
+	src/autolink.c \
+	src/buffer.c \
+	src/document.c \
+	src/escape.c \
+	src/html.c \
+	src/html_blocks.c \
+	src/html5_blocks.c \
+	src/html_smartypants.c \
+	src/stack.c \
+	src/hash.c \
+	src/version.c
+
+test-issues-67: test/issues_67.c $(ISSUE67_SRC)
+	clang -g -O0 -std=c99 -D_DEFAULT_SOURCE -fsanitize=address,undefined \
+		-fno-omit-frame-pointer -Isrc -Wno-static-in-inline \
+		-o ./test/issues_67.out test/issues_67.c $(ISSUE67_SRC)
+	UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./test/issues_67.out
+
 # Housekeeping
 
 clean:

--- a/src/autolink.c
+++ b/src/autolink.c
@@ -192,7 +192,7 @@ hoedown_autolink__email(
 	int nb = 0, np = 0;
 
 	for (rewind = 0; rewind < max_rewind; ++rewind) {
-		uint8_t c = data[-1 - rewind];
+		uint8_t c = *(data - rewind - 1);
 
 		if (isalnum(c))
 			continue;
@@ -249,7 +249,7 @@ hoedown_autolink__url(
 	if (size < 4 || data[1] != '/' || data[2] != '/')
 		return 0;
 
-	while (rewind < max_rewind && isalpha(data[-1 - rewind]))
+	while (rewind < max_rewind && isalpha(*(data - rewind - 1)))
 		rewind++;
 
 	if (!hoedown_autolink_is_safe(data - rewind, size + rewind))

--- a/test/issues_67.c
+++ b/test/issues_67.c
@@ -1,0 +1,47 @@
+/*
+ * https://github.com/kjdev/hoextdown/issues/67
+ *
+ * Regression test for pointer underflow in hoedown_autolink__url and
+ * hoedown_autolink__email caused by the unsigned promotion of `-1 - rewind`.
+ * Built with AddressSanitizer + UndefinedBehaviorSanitizer; the previous
+ * implementation reliably tripped UBSan ("addition of unsigned offset
+ * overflowed") on any autolink input where max_rewind > 0.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "buffer.h"
+#include "document.h"
+#include "html.h"
+
+static void
+render(const char *input)
+{
+	hoedown_extensions ext = (hoedown_extensions)HOEDOWN_EXT_AUTOLINK;
+	hoedown_buffer *ob = hoedown_buffer_new(64);
+	hoedown_renderer *renderer = hoedown_html_renderer_new((hoedown_html_flags)0, 0);
+	hoedown_document *doc = hoedown_document_new(
+		renderer, ext, /*max_nesting=*/16, /*attr_activation=*/0,
+		/*user_block=*/NULL, /*meta=*/NULL);
+
+	hoedown_document_render(doc, ob, (const uint8_t *)input, strlen(input));
+
+	hoedown_document_free(doc);
+	hoedown_html_renderer_free(renderer);
+	hoedown_buffer_free(ob);
+}
+
+int
+main(void)
+{
+	/* URL autolink: triggers hoedown_autolink__url with max_rewind > 0,
+	 * which is the exact site reported in issue #67 (autolink.c:252). */
+	render("see http://example.com here");
+
+	/* Email autolink: same unsigned-promotion problem at autolink.c:195. */
+	render("contact user@example.com today");
+
+	return 0;
+}


### PR DESCRIPTION
Fixed #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a pointer underflow issue in autolink parsing for email and URL detection.

* **Tests**
  * Added regression test to verify autolink handling and prevent future pointer underflow issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/hoextdown/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->